### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere Models - using litellm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pyyaml
 python-telegram-bot
 anthropic==0.3.8
+litellm==0.1.226
 GoogleBard==2.1.0

--- a/utils/litellm_utils.py
+++ b/utils/litellm_utils.py
@@ -1,0 +1,59 @@
+import litellm
+from config import claude_api
+
+class liteLLM:
+    def __init__(self):
+        self.model = "gpt-3.5-turbo"
+        self.temperature = 0.7
+        self.prompt = ""
+
+    def reset(self):
+        self.prompt = ""
+
+    def change_model(self, model):
+        # see litellm supported models here: https://litellm.readthedocs.io/en/latest/supported/
+        if model in litellm.model_list:
+            self.model = model
+            return True
+        return False
+
+    def change_temperature(self, temperature):
+        try:
+            temperature = float(temperature)
+        except ValueError:
+            return False
+        if 0 <= temperature <= 1:
+            self.temperature = temperature
+            return True
+        return False
+
+    def change_cutoff(self, cutoff):
+        try:
+            cutoff = int(cutoff)
+        except ValueError:
+            return False
+        if cutoff > 0:
+            self.cutoff = cutoff
+            return True
+        return False
+
+    async def send_message_stream(self, message):
+        messages = [
+                { "role": "system", "content": self.prompt },
+                { "role": "user", "content": message }
+            ]
+        
+        # call models using gpt3.5 format
+        # use Azure, OpenAI, Anthropic, Cohere, Replicate, Bard LLMs
+        response = await litellm.completion(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+            stream=True,
+        )
+        answer = ""
+
+        async for chunk in response:
+            chunk_message = chunk['choices'][0]['delta']
+            yield answer
+


### PR DESCRIPTION
I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic, Replicate API Endpoints

This PR adds support for models from all the above mentioned providers (by creating a class liteLLM)

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```