### PR TITLE
Switch to Claude3 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ If you only have access to one of the models, you can still continue to use this
 - `/mode`: switch between Claude and Bard
 - `/model NAME`: change model (**Claude only**)
   - **Options:**
-            claude-2,
-            claude-instant-1
+            claude-3-opus-20240229
+            claude-3-sonett-20240229
 - `/temp VALUE`: set temperature (**Claude only**)
   - **Range:** float in [0, 1]
   - **Impact:** amount of randomness injected into the response

--- a/utils/claude_utils.py
+++ b/utils/claude_utils.py
@@ -48,7 +48,7 @@ class Claude:
         self.prompt = f"{self.prompt}{HUMAN_PROMPT} {message}{AI_PROMPT}"
         answer = ""
         async with self.client.messages.stream(
-          max_tokens=1024,
+          max_tokens=100000,
           model=self.model,
           messages=[
               {

--- a/utils/claude_utils.py
+++ b/utils/claude_utils.py
@@ -50,6 +50,7 @@ class Claude:
         async with self.client.messages.stream(
           max_tokens=100000,
           model=self.model,
+          temperature=self.temperature,
           messages=[
               {
                   "role": "user",

--- a/utils/claude_utils.py
+++ b/utils/claude_utils.py
@@ -5,7 +5,7 @@ from config import claude_api
 
 class Claude:
     def __init__(self):
-        self.model = "claude-2"
+        self.model = "claude-3-opus-20240229"
         self.temperature = 0.7
         self.cutoff = 50
         self.client = AsyncAnthropic(api_key=claude_api)
@@ -18,7 +18,7 @@ class Claude:
         self.prompt = self.prompt[: self.prompt.rfind(HUMAN_PROMPT)]
 
     def change_model(self, model):
-        valid_models = {"claude-2", "claude-instant-1"}
+        valid_models = {"claude-3-opus-20240229", "claude-3-sonett-20240229"}
         if model in valid_models:
             self.model = model
             return True
@@ -44,17 +44,22 @@ class Claude:
             return True
         return False
 
-    async def send_message_stream(self, message):
+    async def send_message_stream(self, message) -> None:
         self.prompt = f"{self.prompt}{HUMAN_PROMPT} {message}{AI_PROMPT}"
-        response = await self.client.completions.create(
-            prompt=self.prompt,
-            model=self.model,
-            temperature=self.temperature,
-            stream=True,
-            max_tokens_to_sample=100000,
-        )
         answer = ""
-        async for data in response:
-            answer = f"{answer}{data.completion}"
+        async with self.client.messages.stream(
+          max_tokens=1024,
+          model=self.model,
+          messages=[
+              {
+                  "role": "user",
+                  "content": self.prompt,
+              }
+            ],
+        ) as stream:
+          async for text in stream.text_stream:
+            answer = f"{answer}{text}"
             yield answer
         self.prompt = f"{self.prompt}{answer}"
+        message = await stream.get_final_message()
+        print(message.model_dump_json(indent=2))

--- a/utils/claude_utils.py
+++ b/utils/claude_utils.py
@@ -48,7 +48,7 @@ class Claude:
         self.prompt = f"{self.prompt}{HUMAN_PROMPT} {message}{AI_PROMPT}"
         answer = ""
         async with self.client.messages.stream(
-          max_tokens=100000,
+          max_tokens=4096,
           model=self.model,
           temperature=self.temperature,
           messages=[


### PR DESCRIPTION
This PR applies changes that make the switch to the new API needed for Claude3 models and removes support for the old models.

If you deem it to be necessary, we could do a conditional switch for older models to continue supporting them. 

I had no luck with just doing a drop-in replacement of claude-instant-1.2 and claude-2.1 as the messages API generated far too much and continued the conversation by inserting futher questions from "H" (Human) and "A" (Anthrophic) without any of my doing.